### PR TITLE
feat(domain): implement base domain models

### DIFF
--- a/api/TicketManager.Core/Entities/BaseEntities.cs
+++ b/api/TicketManager.Core/Entities/BaseEntities.cs
@@ -1,0 +1,12 @@
+namespace TicketManager.Core.Entities;
+
+public abstract class BaseEntity
+{
+    public int Id { get; set; }
+}
+
+public abstract class AuditableEntity : BaseEntity
+{
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+}

--- a/api/TicketManager.Core/Entities/RefreshToken.cs
+++ b/api/TicketManager.Core/Entities/RefreshToken.cs
@@ -2,10 +2,8 @@ using System.ComponentModel.DataAnnotations;
 
 namespace TicketManager.Core.Entities;
 
-public class RefreshToken
+public class RefreshToken : BaseEntity
 {
-    public int Id { get; set; }
-
     [Required]
     public string Token { get; set; } = string.Empty;
 
@@ -16,7 +14,12 @@ public class RefreshToken
 
     public bool IsExpired => DateTime.UtcNow >= Expires;
 
+    public string? CreatedByIp { get; set; }
+    public string? ReplacedByToken { get; set; }
+
     // Foreign key
     public int UserId { get; set; }
+
+    // Relation
     public User User { get; set; } = null!;
 }

--- a/api/TicketManager.Core/Entities/RefreshToken.cs
+++ b/api/TicketManager.Core/Entities/RefreshToken.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TicketManager.Core.Entities;
+
+public class RefreshToken
+{
+    public int Id { get; set; }
+
+    [Required]
+    public string Token { get; set; } = string.Empty;
+
+    [Required]
+    public DateTime Expires { get; set; }
+
+    public bool IsRevoked { get; set; } = false;
+
+    public bool IsExpired => DateTime.UtcNow >= Expires;
+
+    // Foreign key
+    public int UserId { get; set; }
+    public User User { get; set; } = null!;
+}

--- a/api/TicketManager.Core/Entities/Role.cs
+++ b/api/TicketManager.Core/Entities/Role.cs
@@ -2,13 +2,14 @@ using System.ComponentModel.DataAnnotations;
 
 namespace TicketManager.Core.Entities;
 
-public class Role
+public class Role : BaseEntity
 {
-    public int Id { get; set; }
-
     [Required, MaxLength(50)]
     public string Name { get; set; } = string.Empty;
 
-    // Relations
+    [MaxLength(200)]
+    public string Description { get; set; } = string.Empty;
+
+    // Relation
     public ICollection<User> Users { get; set; } = new List<User>();
 }

--- a/api/TicketManager.Core/Entities/Role.cs
+++ b/api/TicketManager.Core/Entities/Role.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TicketManager.Core.Entities;
+
+public class Role
+{
+    public int Id { get; set; }
+
+    [Required, MaxLength(50)]
+    public string Name { get; set; } = string.Empty;
+
+    // Relations
+    public ICollection<User> Users { get; set; } = new List<User>();
+}

--- a/api/TicketManager.Core/Entities/Ticket.cs
+++ b/api/TicketManager.Core/Entities/Ticket.cs
@@ -1,28 +1,28 @@
 using System.ComponentModel.DataAnnotations;
+using TicketManager.Core.Enums;
 
 namespace TicketManager.Core.Entities;
 
-public class Ticket
+public class Ticket : AuditableEntity
 {
-    public int Id { get; set; }
-
     [Required, MaxLength(200)]
     public string Title { get; set; } = string.Empty;
 
     [Required, MaxLength(2000)]
     public string Description { get; set; } = string.Empty;
 
-    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
-    public DateTime? UpdatedAt { get; set; }
+    public TicketPriority? Priority { get; set; } = TicketPriority.Medium;
 
-    // Foreign keys (relations)
-    public int CreatedById { get; set; }
-    public User CreatedBy { get; set; } = null!;
+    [Required]
+    public TicketStatus Status { get; set; } = TicketStatus.Backlog;
 
-    public int? AssignedToId { get; set; }
-    public User? AssignedTo { get; set; }
+    public DateTime? ClosedAt { get; set; }
 
-    // Example of status
-    [Required, MaxLength(50)]
-    public string Status { get; set; } = "Open";
+    // Foreign key
+    public int? CreatedById { get; set; }
+
+    // Relations
+    public User? CreatedBy { get; set; }
+    public ICollection<User> AssignedUsers { get; set; } = new List<User>();
+    public ICollection<Role> AssignedRoles { get; set; } = new List<Role>();
 }

--- a/api/TicketManager.Core/Entities/Ticket.cs
+++ b/api/TicketManager.Core/Entities/Ticket.cs
@@ -1,10 +1,28 @@
-namespace TicketManager.Core.Entities
+using System.ComponentModel.DataAnnotations;
+
+namespace TicketManager.Core.Entities;
+
+public class Ticket
 {
-    public class Ticket
-    {
-        public int Id { get; set; }
-        public string Title { get; set; } = null!;
-        public string Description { get; set; } = null!;
-        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
-    }
+    public int Id { get; set; }
+
+    [Required, MaxLength(200)]
+    public string Title { get; set; } = string.Empty;
+
+    [Required, MaxLength(2000)]
+    public string Description { get; set; } = string.Empty;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime? UpdatedAt { get; set; }
+
+    // Foreign keys (relations)
+    public int CreatedById { get; set; }
+    public User CreatedBy { get; set; } = null!;
+
+    public int? AssignedToId { get; set; }
+    public User? AssignedTo { get; set; }
+
+    // Example of status
+    [Required, MaxLength(50)]
+    public string Status { get; set; } = "Open";
 }

--- a/api/TicketManager.Core/Entities/User.cs
+++ b/api/TicketManager.Core/Entities/User.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TicketManager.Core.Entities;
+
+public class User
+{
+    public int Id { get; set; }
+
+    [Required, MaxLength(100)]
+    public string Username { get; set; } = string.Empty;
+
+    [Required, EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    public string PasswordHash { get; set; } = string.Empty;
+
+    // Relations
+    public ICollection<Role> Roles { get; set; } = new List<Role>();
+    public ICollection<RefreshToken> RefreshTokens { get; set; } = new List<RefreshToken>();
+
+    // Helper
+    public bool HasRole(string roleName) => Roles.Any(r => r.Name.Equals(roleName, StringComparison.OrdinalIgnoreCase));
+}

--- a/api/TicketManager.Core/Entities/User.cs
+++ b/api/TicketManager.Core/Entities/User.cs
@@ -2,10 +2,8 @@ using System.ComponentModel.DataAnnotations;
 
 namespace TicketManager.Core.Entities;
 
-public class User
+public class User : BaseEntity
 {
-    public int Id { get; set; }
-
     [Required, MaxLength(100)]
     public string Username { get; set; } = string.Empty;
 
@@ -15,10 +13,23 @@ public class User
     [Required]
     public string PasswordHash { get; set; } = string.Empty;
 
+    [Required]
+    public bool IsActive { get; set; } = true;
+
+    public DateTime LastLogin { get; set; }
+
     // Relations
     public ICollection<Role> Roles { get; set; } = new List<Role>();
+    public ICollection<Ticket> CreatedTickets { get; set; } = new List<Ticket>();
+    public ICollection<Ticket> AssignedTickets { get; set; } = new List<Ticket>();
     public ICollection<RefreshToken> RefreshTokens { get; set; } = new List<RefreshToken>();
 
     // Helper
-    public bool HasRole(string roleName) => Roles.Any(r => r.Name.Equals(roleName, StringComparison.OrdinalIgnoreCase));
+    public bool HasRole(params string[] roleNames)
+    {
+        if (Roles == null || Roles.Count == 0) return false;
+
+        return Roles.Any(r => roleNames.Any(name =>
+            r.Name.Equals(name, StringComparison.OrdinalIgnoreCase)));
+    }
 }

--- a/api/TicketManager.Core/Enums/Ticket.cs
+++ b/api/TicketManager.Core/Enums/Ticket.cs
@@ -1,0 +1,15 @@
+namespace TicketManager.Core.Enums;
+
+public enum TicketStatus
+{
+    Backlog = 0,
+    Open = 1,
+    InProgress = 2,
+    Closed = 3
+}
+public enum TicketPriority
+{
+    Low = 0,
+    Medium = 1,
+    High = 2
+}

--- a/api/TicketManager.Infrastructure/Data/TicketManagerDbContext.cs
+++ b/api/TicketManager.Infrastructure/Data/TicketManagerDbContext.cs
@@ -1,21 +1,69 @@
 using Microsoft.EntityFrameworkCore;
 using TicketManager.Core.Entities;
+using System.Collections.Generic;
 
 namespace TicketManager.Infrastructure.Data
 {
     public class TicketManagerDbContext : DbContext
     {
         public TicketManagerDbContext(DbContextOptions<TicketManagerDbContext> options)
-            : base(options)
-        {
-        }
+            : base(options) { }
 
+        public DbSet<User> Users => Set<User>();
+        public DbSet<Role> Roles => Set<Role>();
+        public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
         public DbSet<Ticket> Tickets => Set<Ticket>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
-            // modelBuilder.ApplyConfigurationsFromAssembly(typeof(TicketManagerDbContext).Assembly);
+
+            // User ↔ Role (many-to-many)
+            modelBuilder.Entity<User>()
+                .HasMany(u => u.Roles)
+                .WithMany(r => r.Users)
+                .UsingEntity<Dictionary<string, object>>( // User ↔ Role link seed (Admin ↔ admin)
+                    "UserRoles",
+                    j => j.HasData(
+                        new { RolesId = 1, UsersId = 1 }
+                    )
+                );
+
+            // User ↔ RefreshTokens (one-to-many)
+            modelBuilder.Entity<User>()
+                .HasMany(u => u.RefreshTokens)
+                .WithOne(t => t.User)
+                .HasForeignKey(t => t.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Ticket ↔ User (relations)
+            modelBuilder.Entity<Ticket>()
+                .HasOne(t => t.CreatedBy)
+                .WithMany()
+                .HasForeignKey(t => t.CreatedById)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<Ticket>()
+                .HasOne(t => t.AssignedTo)
+                .WithMany()
+                .HasForeignKey(t => t.AssignedToId)
+                .OnDelete(DeleteBehavior.SetNull);
+
+            // Role seed data
+            modelBuilder.Entity<Role>().HasData(
+                new Role { Id = 1, Name = "Admin" },
+                new Role { Id = 2, Name = "User" }
+            );
+
+            modelBuilder.Entity<User>().HasData(
+                new User
+                {
+                    Id = 1,
+                    Username = "admin",
+                    Email = "admin@ticketmanager.local",
+                    PasswordHash = "HASH_PLACEHOLDER"
+                }
+            );
         }
     }
 }

--- a/api/TicketManager.Infrastructure/Data/TicketManagerDbContext.cs
+++ b/api/TicketManager.Infrastructure/Data/TicketManagerDbContext.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using TicketManager.Core.Entities;
+using TicketManager.Core.Enums;
 using System.Collections.Generic;
 
 namespace TicketManager.Infrastructure.Data
@@ -11,50 +12,88 @@ namespace TicketManager.Infrastructure.Data
 
         public DbSet<User> Users => Set<User>();
         public DbSet<Role> Roles => Set<Role>();
-        public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
         public DbSet<Ticket> Tickets => Set<Ticket>();
+        public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
 
-            // User ↔ Role (many-to-many)
+            // --- User
+            // User <-> Role (many-to-many)
             modelBuilder.Entity<User>()
                 .HasMany(u => u.Roles)
                 .WithMany(r => r.Users)
-                .UsingEntity<Dictionary<string, object>>( // User ↔ Role link seed (Admin ↔ admin)
+                .UsingEntity<Dictionary<string, object>>( // User <-> Role link seed (Admin <-> admin), (Manager & User <-> asmith) 
                     "UserRoles",
                     j => j.HasData(
-                        new { RolesId = 1, UsersId = 1 }
-                    )
+                        new { RolesId = 1, UsersId = 1 },
+                        new { RolesId = 2, UsersId = 3 },
+                        new { RolesId = 3, UsersId = 3 }
+                        )
                 );
 
-            // User ↔ RefreshTokens (one-to-many)
+            // User <-> RefreshTokens (one-to-many)
             modelBuilder.Entity<User>()
                 .HasMany(u => u.RefreshTokens)
                 .WithOne(t => t.User)
                 .HasForeignKey(t => t.UserId)
                 .OnDelete(DeleteBehavior.Cascade);
 
-            // Ticket ↔ User (relations)
+            // IsActive default value
+            modelBuilder.Entity<User>()
+                .Property(u => u.IsActive)
+                .HasDefaultValue(true);
+
+            // --- Ticket
+            // Ticket <-> User (relations)
             modelBuilder.Entity<Ticket>()
                 .HasOne(t => t.CreatedBy)
-                .WithMany()
+                .WithMany(u => u.CreatedTickets)
                 .HasForeignKey(t => t.CreatedById)
-                .OnDelete(DeleteBehavior.Restrict);
-
-            modelBuilder.Entity<Ticket>()
-                .HasOne(t => t.AssignedTo)
-                .WithMany()
-                .HasForeignKey(t => t.AssignedToId)
                 .OnDelete(DeleteBehavior.SetNull);
 
-            // Role seed data
+            modelBuilder.Entity<Ticket>()
+                .HasMany(t => t.AssignedUsers)
+                .WithMany(u => u.AssignedTickets)
+                .UsingEntity(j => j.ToTable("TicketAssignments"));
+
+            // Ticket <-> Role (relation)
+            modelBuilder.Entity<Ticket>()
+                .HasMany(t => t.AssignedRoles)
+                .WithMany()
+                .UsingEntity(j => j.ToTable("TicketRoleAssignments"));
+
+            // Status default value
+            modelBuilder.Entity<Ticket>()
+                .Property(t => t.Status)
+                .HasDefaultValue(TicketStatus.Backlog);
+
+            // Enums conversion for readability (optional)
+            modelBuilder.Entity<Ticket>()
+                .Property(t => t.Status)
+                .HasConversion<string>();
+
+            modelBuilder.Entity<Ticket>()
+                .Property(t => t.Priority)
+                .HasConversion<string>();
+
+            // --- RefreshToken
+            // IsRevoked default value
+            modelBuilder.Entity<RefreshToken>()
+                .Property(r => r.IsRevoked)
+                .HasDefaultValue(false);
+
+            // --- Seed data
+
+            // Roles
             modelBuilder.Entity<Role>().HasData(
                 new Role { Id = 1, Name = "Admin" },
-                new Role { Id = 2, Name = "User" }
+                new Role { Id = 2, Name = "User" },
+                new Role { Id = 3, Name = "Manager" }
             );
 
+            // Users
             modelBuilder.Entity<User>().HasData(
                 new User
                 {
@@ -62,6 +101,42 @@ namespace TicketManager.Infrastructure.Data
                     Username = "admin",
                     Email = "admin@ticketmanager.local",
                     PasswordHash = "HASH_PLACEHOLDER"
+                },
+                new User
+                {
+                    Id = 2,
+                    Username = "jdoe",
+                    Email = "john.doe@ticketmanager.local",
+                    PasswordHash = "HASH_PLACEHOLDER"
+                },
+                new User
+                {
+                    Id = 3,
+                    Username = "asmith",
+                    Email = "anna.smith@ticketmanager.local",
+                    PasswordHash = "HASH_PLACEHOLDER"
+                }
+            );
+            
+            // Tickets
+            modelBuilder.Entity<Ticket>().HasData(
+                new Ticket
+                {
+                    Id = 1,
+                    Title = "Impossible d'accéder à l'application",
+                    Description = "Erreur 500 sur la page d'accueil",
+                    Status = TicketStatus.Open,
+                    Priority = TicketPriority.High,
+                    CreatedById = 2
+                },
+                new Ticket
+                {
+                    Id = 2,
+                    Title = "Demande de fonctionnalité : export CSV",
+                    Description = "Permettre l'export des tickets au format CSV",
+                    Status = TicketStatus.InProgress,
+                    Priority = TicketPriority.Medium,
+                    CreatedById = 3
                 }
             );
         }

--- a/api/TicketManager.Infrastructure/Migrations/20251106162118_SeedInitalData.Designer.cs
+++ b/api/TicketManager.Infrastructure/Migrations/20251106162118_SeedInitalData.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TicketManager.Infrastructure.Data;
@@ -11,9 +12,11 @@ using TicketManager.Infrastructure.Data;
 namespace TicketManager.Infrastructure.Migrations
 {
     [DbContext(typeof(TicketManagerDbContext))]
-    partial class TicketManagerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251106162118_SeedInitalData")]
+    partial class SeedInitalData
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/TicketManager.Infrastructure/Migrations/20251106162118_SeedInitalData.cs
+++ b/api/TicketManager.Infrastructure/Migrations/20251106162118_SeedInitalData.cs
@@ -1,0 +1,258 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace TicketManager.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class SeedInitalData : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                table: "Tickets",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Tickets",
+                type: "character varying(2000)",
+                maxLength: 2000,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AddColumn<int>(
+                name: "AssignedToId",
+                table: "Tickets",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "CreatedById",
+                table: "Tickets",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Status",
+                table: "Tickets",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "Tickets",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Roles",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Roles", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Users",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Username = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Email = table.Column<string>(type: "text", nullable: false),
+                    PasswordHash = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Users", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "RefreshTokens",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Token = table.Column<string>(type: "text", nullable: false),
+                    Expires = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    IsRevoked = table.Column<bool>(type: "boolean", nullable: false),
+                    UserId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RefreshTokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RefreshTokens_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "UserRoles",
+                columns: table => new
+                {
+                    RolesId = table.Column<int>(type: "integer", nullable: false),
+                    UsersId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserRoles", x => new { x.RolesId, x.UsersId });
+                    table.ForeignKey(
+                        name: "FK_UserRoles_Roles_RolesId",
+                        column: x => x.RolesId,
+                        principalTable: "Roles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UserRoles_Users_UsersId",
+                        column: x => x.UsersId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.InsertData(
+                table: "Roles",
+                columns: new[] { "Id", "Name" },
+                values: new object[,]
+                {
+                    { 1, "Admin" },
+                    { 2, "User" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "Users",
+                columns: new[] { "Id", "Email", "PasswordHash", "Username" },
+                values: new object[] { 1, "admin@ticketmanager.local", "HASH_PLACEHOLDER", "admin" });
+
+            migrationBuilder.InsertData(
+                table: "UserRoles",
+                columns: new[] { "RolesId", "UsersId" },
+                values: new object[] { 1, 1 });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tickets_AssignedToId",
+                table: "Tickets",
+                column: "AssignedToId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tickets_CreatedById",
+                table: "Tickets",
+                column: "CreatedById");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RefreshTokens_UserId",
+                table: "RefreshTokens",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserRoles_UsersId",
+                table: "UserRoles",
+                column: "UsersId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tickets_Users_AssignedToId",
+                table: "Tickets",
+                column: "AssignedToId",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tickets_Users_CreatedById",
+                table: "Tickets",
+                column: "CreatedById",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tickets_Users_AssignedToId",
+                table: "Tickets");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tickets_Users_CreatedById",
+                table: "Tickets");
+
+            migrationBuilder.DropTable(
+                name: "RefreshTokens");
+
+            migrationBuilder.DropTable(
+                name: "UserRoles");
+
+            migrationBuilder.DropTable(
+                name: "Roles");
+
+            migrationBuilder.DropTable(
+                name: "Users");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Tickets_AssignedToId",
+                table: "Tickets");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Tickets_CreatedById",
+                table: "Tickets");
+
+            migrationBuilder.DropColumn(
+                name: "AssignedToId",
+                table: "Tickets");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedById",
+                table: "Tickets");
+
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Tickets");
+
+            migrationBuilder.DropColumn(
+                name: "UpdatedAt",
+                table: "Tickets");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                table: "Tickets",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(200)",
+                oldMaxLength: 200);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Tickets",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(2000)",
+                oldMaxLength: 2000);
+        }
+    }
+}

--- a/api/TicketManager.Infrastructure/Migrations/20251113182109_ImplementBaseDomainModels.Designer.cs
+++ b/api/TicketManager.Infrastructure/Migrations/20251113182109_ImplementBaseDomainModels.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TicketManager.Infrastructure.Data;
@@ -11,9 +12,11 @@ using TicketManager.Infrastructure.Data;
 namespace TicketManager.Infrastructure.Migrations
 {
     [DbContext(typeof(TicketManagerDbContext))]
-    partial class TicketManagerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251113182109_ImplementBaseDomainModels")]
+    partial class ImplementBaseDomainModels
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -21,21 +24,6 @@ namespace TicketManager.Infrastructure.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
-
-            modelBuilder.Entity("RoleTicket", b =>
-                {
-                    b.Property<int>("AssignedRolesId")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("TicketId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("AssignedRolesId", "TicketId");
-
-                    b.HasIndex("TicketId");
-
-                    b.ToTable("TicketRoleAssignments", (string)null);
-                });
 
             modelBuilder.Entity("TicketManager.Core.Entities.RefreshToken", b =>
                 {
@@ -52,9 +40,7 @@ namespace TicketManager.Infrastructure.Migrations
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<bool>("IsRevoked")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("boolean")
-                        .HasDefaultValue(false);
+                        .HasColumnType("boolean");
 
                     b.Property<string>("ReplacedByToken")
                         .HasColumnType("text");
@@ -82,9 +68,7 @@ namespace TicketManager.Infrastructure.Migrations
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Description")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
@@ -124,13 +108,16 @@ namespace TicketManager.Infrastructure.Migrations
 
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
+                    b.Property<int?>("AssignedToId")
+                        .HasColumnType("integer");
+
                     b.Property<DateTime?>("ClosedAt")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<int?>("CreatedById")
+                    b.Property<int>("CreatedById")
                         .HasColumnType("integer");
 
                     b.Property<string>("Description")
@@ -143,9 +130,7 @@ namespace TicketManager.Infrastructure.Migrations
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("text")
-                        .HasDefaultValue("Backlog");
+                        .HasColumnType("text");
 
                     b.Property<string>("Title")
                         .IsRequired()
@@ -155,9 +140,16 @@ namespace TicketManager.Infrastructure.Migrations
                     b.Property<DateTime?>("UpdatedAt")
                         .HasColumnType("timestamp with time zone");
 
+                    b.Property<int?>("UserId")
+                        .HasColumnType("integer");
+
                     b.HasKey("Id");
 
+                    b.HasIndex("AssignedToId");
+
                     b.HasIndex("CreatedById");
+
+                    b.HasIndex("UserId");
 
                     b.ToTable("Tickets");
 
@@ -197,9 +189,7 @@ namespace TicketManager.Infrastructure.Migrations
                         .HasColumnType("text");
 
                     b.Property<bool>("IsActive")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("boolean")
-                        .HasDefaultValue(true);
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("LastLogin")
                         .HasColumnType("timestamp with time zone");
@@ -247,21 +237,6 @@ namespace TicketManager.Infrastructure.Migrations
                         });
                 });
 
-            modelBuilder.Entity("TicketUser", b =>
-                {
-                    b.Property<int>("AssignedTicketsId")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("AssignedUsersId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("AssignedTicketsId", "AssignedUsersId");
-
-                    b.HasIndex("AssignedUsersId");
-
-                    b.ToTable("TicketAssignments", (string)null);
-                });
-
             modelBuilder.Entity("UserRoles", b =>
                 {
                     b.Property<int>("RolesId")
@@ -294,21 +269,6 @@ namespace TicketManager.Infrastructure.Migrations
                         });
                 });
 
-            modelBuilder.Entity("RoleTicket", b =>
-                {
-                    b.HasOne("TicketManager.Core.Entities.Role", null)
-                        .WithMany()
-                        .HasForeignKey("AssignedRolesId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("TicketManager.Core.Entities.Ticket", null)
-                        .WithMany()
-                        .HasForeignKey("TicketId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-                });
-
             modelBuilder.Entity("TicketManager.Core.Entities.RefreshToken", b =>
                 {
                     b.HasOne("TicketManager.Core.Entities.User", "User")
@@ -322,27 +282,24 @@ namespace TicketManager.Infrastructure.Migrations
 
             modelBuilder.Entity("TicketManager.Core.Entities.Ticket", b =>
                 {
-                    b.HasOne("TicketManager.Core.Entities.User", "CreatedBy")
-                        .WithMany("CreatedTickets")
-                        .HasForeignKey("CreatedById")
+                    b.HasOne("TicketManager.Core.Entities.User", "AssignedTo")
+                        .WithMany()
+                        .HasForeignKey("AssignedToId")
                         .OnDelete(DeleteBehavior.SetNull);
 
-                    b.Navigation("CreatedBy");
-                });
-
-            modelBuilder.Entity("TicketUser", b =>
-                {
-                    b.HasOne("TicketManager.Core.Entities.Ticket", null)
+                    b.HasOne("TicketManager.Core.Entities.User", "CreatedBy")
                         .WithMany()
-                        .HasForeignKey("AssignedTicketsId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .HasForeignKey("CreatedById")
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.HasOne("TicketManager.Core.Entities.User", null)
-                        .WithMany()
-                        .HasForeignKey("AssignedUsersId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .WithMany("Tickets")
+                        .HasForeignKey("UserId");
+
+                    b.Navigation("AssignedTo");
+
+                    b.Navigation("CreatedBy");
                 });
 
             modelBuilder.Entity("UserRoles", b =>
@@ -362,9 +319,9 @@ namespace TicketManager.Infrastructure.Migrations
 
             modelBuilder.Entity("TicketManager.Core.Entities.User", b =>
                 {
-                    b.Navigation("CreatedTickets");
-
                     b.Navigation("RefreshTokens");
+
+                    b.Navigation("Tickets");
                 });
 #pragma warning restore 612, 618
         }

--- a/api/TicketManager.Infrastructure/Migrations/20251113182109_ImplementBaseDomainModels.cs
+++ b/api/TicketManager.Infrastructure/Migrations/20251113182109_ImplementBaseDomainModels.cs
@@ -1,0 +1,229 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace TicketManager.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class ImplementBaseDomainModels : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsActive",
+                table: "Users",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastLogin",
+                table: "Users",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Status",
+                table: "Tickets",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ClosedAt",
+                table: "Tickets",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Priority",
+                table: "Tickets",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "UserId",
+                table: "Tickets",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "Roles",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedByIp",
+                table: "RefreshTokens",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ReplacedByToken",
+                table: "RefreshTokens",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "Description",
+                value: "");
+
+            migrationBuilder.UpdateData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "Description",
+                value: "");
+
+            migrationBuilder.InsertData(
+                table: "Roles",
+                columns: new[] { "Id", "Description", "Name" },
+                values: new object[] { 3, "", "Manager" });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "IsActive", "LastLogin" },
+                values: new object[] { true, new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified) });
+
+            migrationBuilder.InsertData(
+                table: "Users",
+                columns: new[] { "Id", "Email", "IsActive", "LastLogin", "PasswordHash", "Username" },
+                values: new object[,]
+                {
+                    { 2, "john.doe@ticketmanager.local", true, new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), "HASH_PLACEHOLDER", "jdoe" },
+                    { 3, "anna.smith@ticketmanager.local", true, new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), "HASH_PLACEHOLDER", "asmith" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "Tickets",
+                columns: new[] { "Id", "AssignedToId", "ClosedAt", "CreatedAt", "CreatedById", "Description", "Priority", "Status", "Title", "UpdatedAt", "UserId" },
+                values: new object[,]
+                {
+                    { 1, null, null, new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), 2, "Erreur 500 sur la page d'accueil", "High", "Open", "Impossible d'accéder à l'application", null, null },
+                    { 2, null, null, new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), 3, "Permettre l'export des tickets au format CSV", "Medium", "InProgress", "Demande de fonctionnalité : export CSV", null, null }
+                });
+
+            migrationBuilder.InsertData(
+                table: "UserRoles",
+                columns: new[] { "RolesId", "UsersId" },
+                values: new object[,]
+                {
+                    { 2, 3 },
+                    { 3, 3 }
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tickets_UserId",
+                table: "Tickets",
+                column: "UserId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tickets_Users_UserId",
+                table: "Tickets",
+                column: "UserId",
+                principalTable: "Users",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tickets_Users_UserId",
+                table: "Tickets");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Tickets_UserId",
+                table: "Tickets");
+
+            migrationBuilder.DeleteData(
+                table: "Tickets",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "Tickets",
+                keyColumn: "Id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "UserRoles",
+                keyColumns: new[] { "RolesId", "UsersId" },
+                keyValues: new object[] { 2, 3 });
+
+            migrationBuilder.DeleteData(
+                table: "UserRoles",
+                keyColumns: new[] { "RolesId", "UsersId" },
+                keyValues: new object[] { 3, 3 });
+
+            migrationBuilder.DeleteData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: 3);
+
+            migrationBuilder.DeleteData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 3);
+
+            migrationBuilder.DropColumn(
+                name: "IsActive",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "LastLogin",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "ClosedAt",
+                table: "Tickets");
+
+            migrationBuilder.DropColumn(
+                name: "Priority",
+                table: "Tickets");
+
+            migrationBuilder.DropColumn(
+                name: "UserId",
+                table: "Tickets");
+
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "Roles");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedByIp",
+                table: "RefreshTokens");
+
+            migrationBuilder.DropColumn(
+                name: "ReplacedByToken",
+                table: "RefreshTokens");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Status",
+                table: "Tickets",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+        }
+    }
+}

--- a/api/TicketManager.Infrastructure/Migrations/20251113222637_FixAndImproveBase.Designer.cs
+++ b/api/TicketManager.Infrastructure/Migrations/20251113222637_FixAndImproveBase.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TicketManager.Infrastructure.Data;
@@ -11,9 +12,11 @@ using TicketManager.Infrastructure.Data;
 namespace TicketManager.Infrastructure.Migrations
 {
     [DbContext(typeof(TicketManagerDbContext))]
-    partial class TicketManagerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251113222637_FixAndImproveBase")]
+    partial class FixAndImproveBase
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/TicketManager.Infrastructure/Migrations/20251113222637_FixAndImproveBase.cs
+++ b/api/TicketManager.Infrastructure/Migrations/20251113222637_FixAndImproveBase.cs
@@ -1,0 +1,273 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TicketManager.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixAndImproveBase : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tickets_Users_AssignedToId",
+                table: "Tickets");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tickets_Users_CreatedById",
+                table: "Tickets");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tickets_Users_UserId",
+                table: "Tickets");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Tickets_AssignedToId",
+                table: "Tickets");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Tickets_UserId",
+                table: "Tickets");
+
+            migrationBuilder.DropColumn(
+                name: "AssignedToId",
+                table: "Tickets");
+
+            migrationBuilder.DropColumn(
+                name: "UserId",
+                table: "Tickets");
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsActive",
+                table: "Users",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true,
+                oldClrType: typeof(bool),
+                oldType: "boolean");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Status",
+                table: "Tickets",
+                type: "text",
+                nullable: false,
+                defaultValue: "Backlog",
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "CreatedById",
+                table: "Tickets",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Roles",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsRevoked",
+                table: "RefreshTokens",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false,
+                oldClrType: typeof(bool),
+                oldType: "boolean");
+
+            migrationBuilder.CreateTable(
+                name: "TicketAssignments",
+                columns: table => new
+                {
+                    AssignedTicketsId = table.Column<int>(type: "integer", nullable: false),
+                    AssignedUsersId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TicketAssignments", x => new { x.AssignedTicketsId, x.AssignedUsersId });
+                    table.ForeignKey(
+                        name: "FK_TicketAssignments_Tickets_AssignedTicketsId",
+                        column: x => x.AssignedTicketsId,
+                        principalTable: "Tickets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_TicketAssignments_Users_AssignedUsersId",
+                        column: x => x.AssignedUsersId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TicketRoleAssignments",
+                columns: table => new
+                {
+                    AssignedRolesId = table.Column<int>(type: "integer", nullable: false),
+                    TicketId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TicketRoleAssignments", x => new { x.AssignedRolesId, x.TicketId });
+                    table.ForeignKey(
+                        name: "FK_TicketRoleAssignments_Roles_AssignedRolesId",
+                        column: x => x.AssignedRolesId,
+                        principalTable: "Roles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_TicketRoleAssignments_Tickets_TicketId",
+                        column: x => x.TicketId,
+                        principalTable: "Tickets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TicketAssignments_AssignedUsersId",
+                table: "TicketAssignments",
+                column: "AssignedUsersId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TicketRoleAssignments_TicketId",
+                table: "TicketRoleAssignments",
+                column: "TicketId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tickets_Users_CreatedById",
+                table: "Tickets",
+                column: "CreatedById",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tickets_Users_CreatedById",
+                table: "Tickets");
+
+            migrationBuilder.DropTable(
+                name: "TicketAssignments");
+
+            migrationBuilder.DropTable(
+                name: "TicketRoleAssignments");
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsActive",
+                table: "Users",
+                type: "boolean",
+                nullable: false,
+                oldClrType: typeof(bool),
+                oldType: "boolean",
+                oldDefaultValue: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Status",
+                table: "Tickets",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldDefaultValue: "Backlog");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "CreatedById",
+                table: "Tickets",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "AssignedToId",
+                table: "Tickets",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "UserId",
+                table: "Tickets",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Roles",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(200)",
+                oldMaxLength: 200);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsRevoked",
+                table: "RefreshTokens",
+                type: "boolean",
+                nullable: false,
+                oldClrType: typeof(bool),
+                oldType: "boolean",
+                oldDefaultValue: false);
+
+            migrationBuilder.UpdateData(
+                table: "Tickets",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "AssignedToId", "UserId" },
+                values: new object[] { null, null });
+
+            migrationBuilder.UpdateData(
+                table: "Tickets",
+                keyColumn: "Id",
+                keyValue: 2,
+                columns: new[] { "AssignedToId", "UserId" },
+                values: new object[] { null, null });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tickets_AssignedToId",
+                table: "Tickets",
+                column: "AssignedToId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tickets_UserId",
+                table: "Tickets",
+                column: "UserId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tickets_Users_AssignedToId",
+                table: "Tickets",
+                column: "AssignedToId",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tickets_Users_CreatedById",
+                table: "Tickets",
+                column: "CreatedById",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tickets_Users_UserId",
+                table: "Tickets",
+                column: "UserId",
+                principalTable: "Users",
+                principalColumn: "Id");
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces the initial domain model structure for TicketManager.
Closes #10 

Includes :
- User, Role, Ticket, RefreshToken models
- Relationships for; User <-> Role (many-to-many), 
User <-> Ticket (one-to-many, via `CreatedBy` et `AssignedUsers`), 
User <-> RefreshToken (one-to-many), 
- Updated migrations
- Preliminary structure validation and DB schema testing

Tests :
- Schema consistency check using SQL commands
- Validation of deletion behaviors (CASCADE, SET NULL, RESTRICT)
- Validation of uniqueness constraints and default values